### PR TITLE
Fix is_supported_platform.h for LLVM on AArch64

### DIFF
--- a/src/is_supported_platform.h
+++ b/src/is_supported_platform.h
@@ -30,7 +30,7 @@
 #define DT_SUPPORTED_X86 0
 #endif
 
-#if defined(__aarch64__) && (defined(__ARM_64BIT_STATE) && defined(__ARM_ARCH) && defined(__ARM_ARCH_8A) || defined(__APPLE__) || defined(__MINGW64__))
+#if defined(__aarch64__) && (defined(__ARM_64BIT_STATE) && defined(__ARM_ARCH) && (defined(__ARM_ARCH_8A) || __ARM_ARCH_PROFILE == 'A') || defined(__APPLE__) || defined(__MINGW64__))
 #define DT_SUPPORTED_ARMv8A 1
 #else
 #define DT_SUPPORTED_ARMv8A 0


### PR DESCRIPTION
Enables compilation with Clang on AArch64. Clang doesn't support `__ARM_ARCH_8A`, but that can be fixed using `__ARM_ARCH_PROFILE`.

In contrast to GCC, Clang supports the OpenMP SIMD pragmas. So this patch also opens a path for building darktable with OpenMP enabled on Aarch64.